### PR TITLE
Env name for api_key

### DIFF
--- a/src/config/campaignmonitor.php
+++ b/src/config/campaignmonitor.php
@@ -2,7 +2,7 @@
 
 return [
 
-    'api_key' => env('CAMPAIGN_MONITOR_API_KEY', null),
+    'api_key' => env('CAMPAIGNMONITOR_API_KEY', null),
 
     'client_id' => env('CAMPAIGNMONITOR_CLIENT_ID', null),
 


### PR DESCRIPTION
Consistent variable name, also the documentation says `CAMPAIGNMONITOR_API_KEY` instead of `CAMPAIGN MONITOR_API_KEY` :)