### PR TITLE
Update campaignmonitor/createsend-php constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=5.4.0",
         "illuminate/support": "~5.0",
-        "campaignmonitor/createsend-php": "5.0.*"
+        "campaignmonitor/createsend-php": "^5.1"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Use the latests from `campaignmonitor/createsend-php` which includes:

```
## v5.1.2 - 6th April, 2017
* Added support for Behavioral Event data
```